### PR TITLE
Document why subjectAltName (SAN) is needed

### DIFF
--- a/TestCertificates/GenerateCertificates.bat
+++ b/TestCertificates/GenerateCertificates.bat
@@ -24,7 +24,7 @@ openssl.exe pkcs12 -in ClientCert.pfx -out ClientCert.pem -nodes
 
 
 :: Generate web server certificate from root certificate
-:: Use OpenSSL instead of makecert since we need the "subjectAltName" extension
+:: Use OpenSSL instead of makecert since we need the "subjectAltName" extension to avoid "Not secure" warnings in web browsers
 ::
 :: Create certificate signing request (CSR)
 :: Doc: https://www.openssl.org/docs/manmaster/man1/openssl-req.html


### PR DESCRIPTION
Fixes #7, assuming my understanding is correct. Please note that I might very well be wrong on this, since I barely know the topic.

Chrome documentation: https://developer.chrome.com/blog/chrome-58-deprecations/#remove-support-for-commonname-matching-in-certificates